### PR TITLE
Small fix to session.isActive() inside verify-request.ts

### DIFF
--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -49,7 +49,11 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
 
     if (session) {
       // Verify session is valid
-      if (session.isActive()) {
+      if (
+        Shopify.Context.SCOPES.equals(session.scope) && 
+        session.accessToken &&
+        (!session.expires || session.expires >= new Date())
+        ) {
         try {
           // I think we need to verify on Shopify's side that the access token is valid, because otherwise anyone could just make their own 'valid' token and use it.
           //   Of course if we're making requests to Shopify's API afterwords it will fail with an error, but we still need this check since we aren't always making a Shopify request when verifying this token (it might be an API request for our server, and we need to be sure it's the correct user).


### PR DESCRIPTION
First of all big thanks for creating this repo 👍 It's a shame Shopify is deprecating the original.

While trying out this repo I encountered an error, "`session.isActive() is not a function`". I use Mongodb as my custom session storage and realized `isActive()` does not save into the session object (in my case I'm using JSON.stringify() to save my session object, as per [shopify-node-api's documentation](https://github.com/Shopify/shopify-node-api/blob/main/docs/usage/customsessions.md#create-a-redisstore-class), which doesn't serialize methods) and so will be undefined when called after loading the session.

The method is being called [here](https://github.com/TheSecurityDev/simple-koa-shopify-auth/blob/f2369ba14112e3fc0e6d7d8cb566d260dba82629/src/verify-request.ts#L52).
```js
// original
if (session) {
  // Verify session is valid
  if (session.isActive())
...
```
I replaced this method call with the actual business logic from [Shopify's own code](https://github.com/Shopify/shopify-node-api/blob/6a6a42b7b6a71871feda510b27ab1d3836bcfe0a/src/auth/session/session.ts#L38) used for checking if the session is active, which removes the responsibility from the `session` object.

```js
// fix
if (session) {
  // Verify session is valid
  if (
    Shopify.Context.SCOPES.equals(session.scope) && 
    session.accessToken &&
    (!session.expires || session.expires >= new Date())
    ) {
    ...
```