### PR TITLE
Use token exchange instead of redirecting for online session

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ _NOTE: These parameters differ from the ones in the official library._
   accessMode: "online",  // The access mode of the token to check
   authRoute: "/auth",  // Where to redirect if the session is invalid
   returnHeader: false,  // If true, set headers instead of redirecting if session is invalid
-  async afterSessionRefresh(ctx, session) { }  // Callback function after the session is refreshed using the token exchange endpoint
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ _Importing differs slightly from the official library in that the `createShopify
 For requests, create the middleware like this:
 
 ```js
-// For requests from the frontend, we want to return headers, so we can check if we need to reauth on the client side
+// For API requests from the frontend, we want to return headers, so we can check if we need to reauthenticate on the client side.
+// NOTE: Now this isn't needed as often since we use the token exchange endpoint to get the online token.
 const verifyApiRequest = verifyRequest({ returnHeader: true });
 const verifyPageRequest = verifyRequest();
 ```
@@ -69,6 +70,7 @@ _NOTE: These parameters differ from the ones in the official library._
   accessMode: "online",  // The access mode of the token to check
   authRoute: "/auth",  // Where to redirect if the session is invalid
   returnHeader: false,  // If true, set headers instead of redirecting if session is invalid
+  async afterSessionRefresh(ctx, session) { }  // Callback function after the session is refreshed using the token exchange endpoint
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-koa-shopify-auth",
-  "version": "2.1.17",
+  "version": "3.0.0",
   "description": "A better, simplified version of the now deprecated @Shopify/koa-shopify-auth middleware library. It removes the use of cookies for sessions (which greatly smooths the auth process), replaces a deprecated API call, and supports v2 of the official @shopify/shopify-api package.",
   "author": "TheSecurityDev",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-koa-shopify-auth",
   "version": "2.1.17",
-  "description": "A better, simplified version of the (no longer supported) @Shopify/koa-shopify-auth middleware library. It removes the use of cookies for sessions (which greatly smooths the auth process), replaces a deprecated API call, and supports v2 of the official @shopify/shopify-api package.",
+  "description": "A better, simplified version of the now deprecated @Shopify/koa-shopify-auth middleware library. It removes the use of cookies for sessions (which greatly smooths the auth process), replaces a deprecated API call, and supports v2 of the official @shopify/shopify-api package.",
   "author": "TheSecurityDev",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
     "lru-cache": "^10.2.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^5.0.1"
+    "@shopify/shopify-api": "^5.3.0"
   },
   "devDependencies": {
     "@types/koa": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "lru-cache": "^9.1.2"
+    "lru-cache": "^10.2.0"
   },
   "peerDependencies": {
     "@shopify/shopify-api": "^5.0.1"

--- a/src/create-shopify-auth.ts
+++ b/src/create-shopify-auth.ts
@@ -10,7 +10,7 @@ import {
 type OAuthBeginConfig = {
   accessMode?: "online" | "offline";
   authPath?: string;
-  afterAuth(ctx: Context): Promise<void>;
+  afterAuth(ctx: Context): Promise<boolean | void>;
 };
 
 export default function createShopifyAuth(options: OAuthBeginConfig) {
@@ -74,7 +74,8 @@ export default function createShopifyAuth(options: OAuthBeginConfig) {
           query as unknown as AuthQuery
         );
         ctx.state.shopify = session;
-        await config.afterAuth?.(ctx);
+        const continueNext = await config.afterAuth?.(ctx);
+        if (continueNext === false) return; // If the afterAuth function returns false, don't continue to the next middleware
       } catch (err) {
         const message = (err as Error).message;
         switch (true) {

--- a/src/create-shopify-auth.ts
+++ b/src/create-shopify-auth.ts
@@ -74,9 +74,7 @@ export default function createShopifyAuth(options: OAuthBeginConfig) {
           query as unknown as AuthQuery
         );
         ctx.state.shopify = session;
-        if (config.afterAuth) {
-          await config.afterAuth(ctx);
-        }
+        await config.afterAuth?.(ctx);
       } catch (err) {
         const message = (err as Error).message;
         switch (true) {

--- a/src/create-shopify-auth.ts
+++ b/src/create-shopify-auth.ts
@@ -10,7 +10,7 @@ import {
 type OAuthBeginConfig = {
   accessMode?: "online" | "offline";
   authPath?: string;
-  afterAuth(ctx: Context): Promise<boolean | void>;
+  afterAuth(ctx: Context): Promise<void>;
 };
 
 export default function createShopifyAuth(options: OAuthBeginConfig) {
@@ -74,8 +74,7 @@ export default function createShopifyAuth(options: OAuthBeginConfig) {
           query as unknown as AuthQuery
         );
         ctx.state.shopify = session;
-        const continueNext = await config.afterAuth?.(ctx);
-        if (continueNext === false) return; // If the afterAuth function returns false, don't continue to the next middleware
+        await config.afterAuth?.(ctx);
       } catch (err) {
         const message = (err as Error).message;
         switch (true) {

--- a/src/create-shopify-auth.ts
+++ b/src/create-shopify-auth.ts
@@ -6,6 +6,7 @@ import {
   shouldPerformTopLevelOAuth,
   startTopLevelOauthRedirect,
 } from "./top-level-oauth-redirect";
+import { validateShop } from "./utils";
 
 type OAuthBeginConfig = {
   accessMode?: "online" | "offline";
@@ -87,8 +88,6 @@ export default function createShopifyAuth(options: OAuthBeginConfig) {
             // This is likely because the OAuth session cookie expired before the merchant approved the request
             ctx.redirect(`${oAuthStartPath}?${querystring}`);
             break;
-          case err instanceof Shopify.Errors.InvalidJwtError:
-            ctx.throw(401, message);
           default:
             ctx.throw(500, message);
         }
@@ -98,9 +97,4 @@ export default function createShopifyAuth(options: OAuthBeginConfig) {
 
     await next();
   };
-}
-
-export function validateShop(shop: string): boolean {
-  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
-  return shopUrlRegex.test(shop);
 }

--- a/src/create-shopify-auth.ts
+++ b/src/create-shopify-auth.ts
@@ -6,7 +6,6 @@ import {
   shouldPerformTopLevelOAuth,
   startTopLevelOauthRedirect,
 } from "./top-level-oauth-redirect";
-import { validateShop } from "./utils";
 
 type OAuthBeginConfig = {
   accessMode?: "online" | "offline";
@@ -43,7 +42,7 @@ export default function createShopifyAuth(options: OAuthBeginConfig) {
       (path === oAuthStartPath && shouldPerformTopLevelOAuth(ctx))
     ) {
       // Auth started
-      if (!validateShop(shop)) {
+      if (!Shopify.Utils.sanitizeShop(shop)) {
         // Invalid shop
         ctx.response.status = 400;
         ctx.response.body = shop ? "Invalid shop parameter" : "Missing shop parameter";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import createShopifyAuth from "./create-shopify-auth";
-import verifyRequest from "./verify-request";
+import verifyRequest, { AuthFailureHeader } from "./verify-request";
 
-export { createShopifyAuth, verifyRequest };
+export { createShopifyAuth, verifyRequest, AuthFailureHeader };
 export { createSession } from "./session";
 export { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";
-export { AuthFailureHeader } from "./utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import createShopifyAuth from "./create-shopify-auth";
 import verifyRequest from "./verify-request";
-import { validateShop } from "./utils";
 
-export { createShopifyAuth, validateShop, verifyRequest };
+export { createShopifyAuth, verifyRequest };
+export { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";
+export { createSession } from "./session";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import createShopifyAuth, { validateShop } from "./create-shopify-auth";
+import createShopifyAuth from "./create-shopify-auth";
 import verifyRequest from "./verify-request";
+import { validateShop } from "./utils";
 
 export { createShopifyAuth, validateShop, verifyRequest };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ import verifyRequest from "./verify-request";
 export { createShopifyAuth, verifyRequest };
 export { createSession } from "./session";
 export { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";
+export { setReauthResponse, ReauthHeader } from "./utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,6 @@ import createShopifyAuth from "./create-shopify-auth";
 import verifyRequest from "./verify-request";
 
 export { createShopifyAuth, verifyRequest };
+export { createSession } from "./session";
 export { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";
+export { AuthFailureHeader } from "./utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@ import createShopifyAuth from "./create-shopify-auth";
 import verifyRequest from "./verify-request";
 
 export { createShopifyAuth, verifyRequest };
-export { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";
 export { createSession } from "./session";
+export { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,4 @@ import createShopifyAuth from "./create-shopify-auth";
 import verifyRequest from "./verify-request";
 
 export { createShopifyAuth, verifyRequest };
-export { createSession } from "./session";
 export { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";
-export { setReauthResponse, ReauthHeader } from "./utils";

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,9 +6,11 @@ export function createSession(responseBody: OnlineAccessResponse, shop: string, 
   const isOnline = !!rest.associated_user; // If there's an associated user, then it's an online access token
 
   // Get the session ID
-  const sessionId = isOnline
-    ? Shopify.Auth.getJwtSessionId(shop, `${rest.associated_user.id}`)
-    : Shopify.Auth.getOfflineSessionId(shop);
+  const sessionId = Shopify.Context.IS_EMBEDDED_APP
+    ? isOnline
+      ? Shopify.Auth.getJwtSessionId(shop, `${rest.associated_user.id}`)
+      : Shopify.Auth.getOfflineSessionId(shop)
+    : `${shop}_${Date.now()}`;
 
   // Initialize the session object
   const session = new Shopify.Session.Session(sessionId, shop, state, isOnline);

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,26 @@
+import Shopify, { OnlineAccessResponse } from "@shopify/shopify-api";
+
+/* Creates a new session from the response from the access token request. */
+export function createSession(responseBody: OnlineAccessResponse, shop: string, state = "") {
+  const { access_token, scope, ...rest } = responseBody;
+  const isOnline = !!rest.associated_user; // If there's an associated user, then it's an online access token
+
+  // Get the session ID
+  const sessionId = isOnline
+    ? Shopify.Auth.getJwtSessionId(shop, `${rest.associated_user.id}`)
+    : Shopify.Auth.getOfflineSessionId(shop);
+
+  // Initialize the session object
+  const session = new Shopify.Session.Session(sessionId, shop, state, isOnline);
+  session.accessToken = access_token;
+  session.scope = scope;
+
+  if (isOnline) {
+    // Add the online access info
+    const sessionExpiration = new Date(Date.now() + responseBody.expires_in * 1000);
+    session.expires = sessionExpiration;
+    session.onlineAccessInfo = rest;
+  }
+
+  return session;
+}

--- a/src/token-exchange.ts
+++ b/src/token-exchange.ts
@@ -10,6 +10,8 @@ export async function exchangeSessionTokenForAccessTokenSession(
   encodedSessionToken: string,
   tokenType: "online" | "offline"
 ) {
+  const sanitizedShop = Shopify.Utils.sanitizeShop(shop, true);
+
   // Construct the request body
   const body = {
     client_id: Shopify.Context.API_KEY,
@@ -21,7 +23,7 @@ export async function exchangeSessionTokenForAccessTokenSession(
   };
 
   // Make the request
-  const response = await fetch(`https://${shop}/admin/oauth/access_token`, {
+  const response = await fetch(`https://${sanitizedShop}/admin/oauth/access_token`, {
     method: "POST",
     body: JSON.stringify(body),
     headers: { "Content-Type": DataType.JSON, Accept: DataType.JSON },

--- a/src/token-exchange.ts
+++ b/src/token-exchange.ts
@@ -42,7 +42,7 @@ export async function exchangeSessionTokenForAccessTokenSession(
   }
 
   // Parse the response
-  const sessionResponse: OnlineAccessResponse = await response.json(); // The returned session is missing the id, so we'll need to add it
+  const sessionResponse: OnlineAccessResponse = await response.json();
 
   // Create and return the session
   return createSession(sessionResponse, shop);

--- a/src/token-exchange.ts
+++ b/src/token-exchange.ts
@@ -1,0 +1,47 @@
+import Shopify, { DataType, OnlineAccessResponse } from "@shopify/shopify-api";
+import { HttpResponseError } from "@shopify/shopify-api/dist/error";
+
+import { createSession } from "./session";
+
+/** Given the shop, encoded JWT session token, and token type, return a session object with an access token.
+    https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange */
+export async function exchangeSessionTokenForAccessTokenSession(
+  shop: string,
+  encodedSessionToken: string,
+  tokenType: "online" | "offline"
+) {
+  // Construct the request body
+  const body = {
+    client_id: Shopify.Context.API_KEY,
+    client_secret: Shopify.Context.API_SECRET_KEY,
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+    subject_token: encodedSessionToken,
+    subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
+    requested_token_type: `urn:shopify:params:oauth:token-type:${tokenType}-access-token`,
+  };
+
+  // Make the request
+  const response = await fetch(`https://${shop}/admin/oauth/access_token`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": DataType.JSON, Accept: DataType.JSON },
+  });
+
+  // Check the response for errors
+  if (!response.ok) {
+    const { status, statusText, headers } = response;
+    throw new HttpResponseError({
+      message: `Failed to exchange session token for access token: ${status} ${statusText}`,
+      code: status,
+      statusText,
+      body,
+      headers: headers as any,
+    });
+  }
+
+  // Parse the response
+  const sessionResponse: OnlineAccessResponse = await response.json(); // The returned session is missing the id, so we'll need to add it
+
+  // Create and return the session
+  return createSession(sessionResponse, shop);
+}

--- a/src/token-exchange.ts
+++ b/src/token-exchange.ts
@@ -5,8 +5,7 @@ import { Session } from "@shopify/shopify-api/dist/auth/session";
 import { createSession } from "./session";
 
 // Cache object with current requests so we can avoid making the same request multiple times.
-// This is useful when multiple API requests are made with an invalid session token, and we don't want to call the callback multiple times.
-// The key is in the format `[tokenType]:[encodedSessionToken]` and the value is the promise of the request.
+// The key is in the format `{shop}:{tokenType}:{encodedSessionToken}:{saveSession}` and the value is the promise of the request.
 const currentTokenExchangeRequests = new Map<string, Promise<Session>>();
 
 /** Given the shop, encoded JWT session token, and token type, return a session object with an access token.

--- a/src/top-level-oauth-redirect.ts
+++ b/src/top-level-oauth-redirect.ts
@@ -37,8 +37,8 @@ export async function startTopLevelOauthRedirect(ctx: Context, apiKey: string, p
   setTopLevelOAuthCookieValue(ctx, "1");
   let { query } = ctx;
   const hostName = Shopify.Context.HOST_NAME; // Use this instead of ctx.host to prevent issues when behind a proxy
-  const shop = query.shop ? query.shop.toString() : "";
-  const host = query.host ? query.host.toString() : "";
+  const shop = Shopify.Utils.sanitizeShop(query.shop?.toString() ?? "") ?? "";
+  const host = Shopify.Utils.sanitizeHost(query.host?.toString() ?? "") ?? "";
   const params = { shop, host };
   const queryString = new URLSearchParams(params).toString(); // Use this instead of ctx.querystring, because it sanitizes the query parameters we are using
   ctx.body = await getTopLevelRedirectScript(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,12 +3,6 @@ import { MissingJwtTokenError, HttpResponseError } from "@shopify/shopify-api/di
 import { JwtPayload } from "@shopify/shopify-api/dist/utils/decode-session-token";
 import { Context } from "koa";
 
-export enum AuthFailureHeader {
-  Reauthorize = "X-Shopify-API-Request-Failure-Reauthorize",
-  ReauthorizeUrl = "X-Shopify-API-Request-Failure-Reauthorize-Url",
-  InvalidSessionTokenError = "X-Shopify-API-Request-Failure-Invalid-Session-Token",
-}
-
 /** Throw the error, unless it's an `HttpResponseError` with status `401`. */
 export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
   if (err instanceof HttpResponseError) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,9 @@ import { Context } from "koa";
 export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
   if (err instanceof HttpResponseError) {
     // NOTE: Shopify API v3+ uses 'response.code' instead of 'code'
-    if ((err as any)?.code === 401 || err.response?.code === 401) {
-      return; // Catch the 401 error so we can re-authorize
+    const code = (err as any)?.code ?? err.response?.code;
+    if (code === 401 || code === 403) {
+      return; // Catch the 401 and 403 errors so we can re-authorize
     }
   }
   throw err; // Throw any other errors

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,8 +8,8 @@ export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
   if (err instanceof HttpResponseError) {
     // NOTE: Shopify API v3+ uses 'response.code' instead of 'code'
     const code = (err as any)?.code ?? err.response?.code;
-    if (code === 401 || code === 403) {
-      return; // Catch the 401 and 403 errors so we can re-authorize
+    if (code === 401) {
+      return; // Catch the 401 error so we can re-authorize
     }
   }
   throw err; // Throw any other errors

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,60 @@
+import Shopify from "@shopify/shopify-api";
+import { MissingJwtTokenError, HttpResponseError } from "@shopify/shopify-api/dist/error";
+import { JwtPayload } from "@shopify/shopify-api/dist/utils/decode-session-token";
+import { Context } from "koa";
+
+/** Return whether the shop matches the expected format. */
+export function validateShop(shop: string): boolean {
+  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
+  return shopUrlRegex.test(shop);
+}
+
+/** Throw the error, unless it's an `HttpResponseError` with status `401`. */
+export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
+  if (err instanceof HttpResponseError) {
+    // NOTE: Shopify API v3+ uses 'response.code' instead of 'code'
+    if ((err as any)?.code === 401 || err.response?.code === 401) {
+      return; // Catch the 401 error so we can re-authorize
+    }
+  }
+  throw err; // Throw any other errors
+}
+
+////////////////////////////
+// Session token utils
+////////////////////////////
+
+/** Find and return the base64 encoded JWT session token from the request authorization header in the given context. Throws an error if it wasn't found. */
+export function getEncodedSessionToken(ctx: Context) {
+  if (Shopify.Context.IS_EMBEDDED_APP) {
+    const authHeader = ctx.req.headers.authorization ?? "";
+    const matches = authHeader?.match(/Bearer (.*)/);
+    if (!matches) throw new MissingJwtTokenError("Missing Bearer token in authorization header");
+    return matches[1];
+  } else {
+    throw new Error("Session tokens are only available in embedded apps");
+  }
+}
+
+// /** Parse and decode the JWT session token from the request context. */
+// function parseAndDecodeSessionToken(ctx: Context) {
+//   const encodedToken = getEncodedSessionToken(ctx);
+//   return Shopify.Utils.decodeSessionToken(encodedToken);
+// }
+
+/** Get the shop from the JWT session token. */
+export function getShopFromSessionToken(sessionToken: JwtPayload) {
+  return sessionToken.dest.replace("https://", "");
+}
+
+/** Get the base64 encoded host from the JWT session token. */
+function getHostFromSessionToken(sessionToken: JwtPayload) {
+  return Buffer.from(sessionToken.iss.replace("https://", "")).toString("base64");
+}
+
+/** Parse given decoded session token and return the shop and host query string params. */
+export function getShopAndHostQueryStringFromSessionToken(sessionToken: JwtPayload) {
+  const shop = getShopFromSessionToken(sessionToken);
+  const host = getHostFromSessionToken(sessionToken);
+  return new URLSearchParams({ shop, host }).toString();
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,14 @@ import { MissingJwtTokenError, HttpResponseError } from "@shopify/shopify-api/di
 import { JwtPayload } from "@shopify/shopify-api/dist/utils/decode-session-token";
 import { Context } from "koa";
 
+/** Return whether the shop matches the expected format.
+ * @deprecated You can use `Shopify.Utils.sanitizeShop` instead (returns `null` if invalid).
+ */
+export function validateShop(shop: string): boolean {
+  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
+  return shopUrlRegex.test(shop);
+}
+
 /** Throw the error, unless it's an `HttpResponseError` with status `401`. */
 export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
   if (err instanceof HttpResponseError) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,14 +3,6 @@ import { MissingJwtTokenError, HttpResponseError } from "@shopify/shopify-api/di
 import { JwtPayload } from "@shopify/shopify-api/dist/utils/decode-session-token";
 import { Context } from "koa";
 
-/** Return whether the shop matches the expected format.
- * @deprecated You can use `Shopify.Utils.sanitizeShop` instead (returns `null` if invalid).
- */
-export function validateShop(shop: string): boolean {
-  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
-  return shopUrlRegex.test(shop);
-}
-
 /** Throw the error, unless it's an `HttpResponseError` with status `401`. */
 export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
   if (err instanceof HttpResponseError) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,7 +20,7 @@ export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
 
 /** Set the response status to 401 and add the appropriate headers to tell the client to reauthorize. */
 export function setReauthResponse(ctx: Context, reauthUrl: string) {
-  ctx.response.status = 401;
+  ctx.response.status = 401; // Set the status to 401
   ctx.response.set(ReauthHeader.Reauthorize, "1"); // Tell the client to re-authorize by setting the reauth header
   ctx.response.set(ReauthHeader.ReauthorizeUrl, reauthUrl); // Tell the client where to re-authorize
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,10 @@ import { MissingJwtTokenError, HttpResponseError } from "@shopify/shopify-api/di
 import { JwtPayload } from "@shopify/shopify-api/dist/utils/decode-session-token";
 import { Context } from "koa";
 
-export enum ReauthHeader {
+export enum AuthFailureHeader {
   Reauthorize = "X-Shopify-API-Request-Failure-Reauthorize",
   ReauthorizeUrl = "X-Shopify-API-Request-Failure-Reauthorize-Url",
+  InvalidSessionTokenError = "X-Shopify-API-Request-Failure-Invalid-Session-Token",
 }
 
 /** Throw the error, unless it's an `HttpResponseError` with status `401`. */
@@ -16,13 +17,6 @@ export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
     if (code === 401) return; // Catch the 401 error so we can re-authorize
   }
   throw err; // Throw any other errors
-}
-
-/** Set the response status to 401 and add the appropriate headers to tell the client to reauthorize. */
-export function setReauthResponse(ctx: Context, reauthUrl: string) {
-  ctx.response.status = 401; // Set the status to 401
-  ctx.response.set(ReauthHeader.Reauthorize, "1"); // Tell the client to re-authorize by setting the reauth header
-  ctx.response.set(ReauthHeader.ReauthorizeUrl, reauthUrl); // Tell the client where to re-authorize
 }
 
 ////////////////////////////

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,9 +8,7 @@ export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
   if (err instanceof HttpResponseError) {
     // NOTE: Shopify API v3+ uses 'response.code' instead of 'code'
     const code = (err as any)?.code ?? err.response?.code;
-    if (code === 401) {
-      return; // Catch the 401 error so we can re-authorize
-    }
+    if (code === 401) return; // Catch the 401 error so we can re-authorize
   }
   throw err; // Throw any other errors
 }
@@ -30,12 +28,6 @@ export function getEncodedSessionToken(ctx: Context) {
     throw new Error("Session tokens are only available in embedded apps");
   }
 }
-
-// /** Parse and decode the JWT session token from the request context. */
-// function parseAndDecodeSessionToken(ctx: Context) {
-//   const encodedToken = getEncodedSessionToken(ctx);
-//   return Shopify.Utils.decodeSessionToken(encodedToken);
-// }
 
 /** Get the shop from the JWT session token. */
 export function getShopFromSessionToken(sessionToken: JwtPayload) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,12 +3,6 @@ import { MissingJwtTokenError, HttpResponseError } from "@shopify/shopify-api/di
 import { JwtPayload } from "@shopify/shopify-api/dist/utils/decode-session-token";
 import { Context } from "koa";
 
-/** Return whether the shop matches the expected format. */
-export function validateShop(shop: string): boolean {
-  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
-  return shopUrlRegex.test(shop);
-}
-
 /** Throw the error, unless it's an `HttpResponseError` with status `401`. */
 export function throwUnlessAuthError(err: HttpResponseError | Error | unknown) {
   if (err instanceof HttpResponseError) {

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -6,12 +6,17 @@ import { LRUCache } from "lru-cache";
 import { exchangeSessionTokenForAccessTokenSession } from "./token-exchange";
 import { setTopLevelOAuthCookieValue } from "./top-level-oauth-redirect";
 import {
-  AuthFailureHeader,
   getEncodedSessionToken,
   getShopFromSessionToken,
   getShopAndHostQueryStringFromSessionToken,
   throwUnlessAuthError,
 } from "./utils";
+
+export enum AuthFailureHeader {
+  Reauthorize = "X-Shopify-API-Request-Failure-Reauthorize",
+  ReauthorizeUrl = "X-Shopify-API-Request-Failure-Reauthorize-Url",
+  InvalidSessionTokenError = "X-Shopify-API-Request-Failure-Invalid-Session-Token",
+}
 
 type VerifyRequestOptions = {
   accessMode?: "online" | "offline";

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -32,11 +32,9 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
   const { accessMode, returnHeader, authRoute } = { ...defaultOptions, ...options };
 
   return async function verifyTokenMiddleware(ctx: Context, next: Next) {
-    // Get shop from query string
-    const { query, querystring } = ctx;
-    const shop = query.shop?.toString() ?? "";
-
     try {
+      const { query, querystring } = ctx;
+
       // Load the user's access token session (this will validate the JWT signature of the request session token, so we know that it was signed by Shopify)
       const sessionData = await Shopify.Utils.loadCurrentSession(
         ctx.req,
@@ -49,9 +47,10 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
         const session = Session.cloneSession(sessionData, sessionData.id);
 
         // Login again if the shops don't match (not every request will have a shop query parameter, so only check if it's present)
-        if (shop && session.shop !== shop) {
+        const shopParam = query.shop?.toString() ?? "";
+        if (shopParam && session.shop !== shopParam) {
           console.warn(
-            `Shop '${shop}' does not match session shop '${session.shop}'. Redirecting to auth route...`
+            `Shop '${shopParam}' does not match session shop '${session.shop}'. Redirecting to auth route...`
           );
           await clearSession(ctx, accessMode);
           ctx.redirect(`${authRoute}?${querystring}`);

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -81,7 +81,7 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
 
       if (encodedSessionToken && sessionToken) {
         const shop = getShopFromSessionToken(sessionToken);
-        // Exchange the session token for a session with an access token
+        // Exchange the session token for a session with an access token and save it to storage
         const session = await exchangeSessionTokenForAccessTokenSession(
           shop,
           encodedSessionToken,

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -24,7 +24,7 @@ type VerifyRequestOptions = {
   authRoute?: string;
 };
 
-const defaultOptions: Omit<Required<VerifyRequestOptions>, "afterSessionRefresh"> = {
+const defaultOptions: Required<VerifyRequestOptions> = {
   accessMode: "online",
   authRoute: "/auth",
   returnHeader: false,

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -81,12 +81,7 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
       if (encodedSessionToken && sessionToken) {
         const shop = getShopFromSessionToken(sessionToken);
         // Exchange the session token for a session with an access token and save it to storage
-        await exchangeSessionTokenForAccessTokenSession(
-          shop,
-          encodedSessionToken,
-          accessMode,
-          true
-        );
+        await exchangeSessionTokenForAccessTokenSession(shop, encodedSessionToken, accessMode);
         // Clear the top level oauth cookie since we have a valid session (maybe not necessary, but just in case)
         setTopLevelOAuthCookieValue(ctx, null);
         // Continue to the next middleware since the session is valid

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -119,18 +119,11 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
 
       // Catch JWT session token errors
     } catch (err: any) {
-      // TODO: We just throw an error even if the token is invalid to avoid breaking changes, but we can change this later if we want to handle it better.
-      // if (err instanceof Shopify.Errors.InvalidJwtError) {
-      //   console.warn(`Invalid JWT token: ${err.message}`);
-      //   ctx.response.status = 403;
-      //   ctx.response.body = "Invalid JWT token";
-      //   return;
-      // } else if (err instanceof Shopify.Errors.MissingJwtTokenError) {
-      //   console.warn(`Missing JWT token: ${err.message}`);
-      //   ctx.response.status = 401;
-      //   ctx.response.body = "Missing JWT token";
-      //   return;
-      // }
+      if (err instanceof Shopify.Errors.InvalidJwtError) {
+        ctx.throw(401, `Invalid JWT token: ${err.message}`);
+      } else if (err instanceof Shopify.Errors.MissingJwtTokenError) {
+        ctx.throw(401, `Missing JWT token: ${err.message}`);
+      }
       ctx.throw(500, err instanceof Error ? err.message : "Unknown error");
     }
   };

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -17,7 +17,6 @@ type VerifyRequestOptions = {
   accessMode?: "online" | "offline";
   returnHeader?: boolean;
   authRoute?: string;
-  afterSessionRefresh?: (ctx: Context, session: Session) => Promise<boolean | void>;
 };
 
 const defaultOptions: Omit<Required<VerifyRequestOptions>, "afterSessionRefresh"> = {
@@ -27,7 +26,7 @@ const defaultOptions: Omit<Required<VerifyRequestOptions>, "afterSessionRefresh"
 };
 
 export default function verifyRequest(options?: VerifyRequestOptions) {
-  const { accessMode, returnHeader, authRoute, afterSessionRefresh } = {
+  const { accessMode, returnHeader, authRoute } = {
     ...defaultOptions,
     ...options,
   };
@@ -82,15 +81,12 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
       if (encodedSessionToken && sessionToken) {
         const shop = getShopFromSessionToken(sessionToken);
         // Exchange the session token for a session with an access token and save it to storage
-        const session = await exchangeSessionTokenForAccessTokenSession(
+        await exchangeSessionTokenForAccessTokenSession(
           shop,
           encodedSessionToken,
           accessMode,
           true
         );
-        // Call the afterSessionRefresh callback if provided
-        const continueNext = await afterSessionRefresh?.(ctx, session);
-        if (continueNext === false) return; // If the callback returns false, then we don't continue to the next middleware
         // Clear the top level oauth cookie since we have a valid session (maybe not necessary, but just in case)
         setTopLevelOAuthCookieValue(ctx, null);
         // Continue to the next middleware since the session is valid

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -110,7 +110,7 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
         ctx.response.status = 401;
         ctx.response.set(REAUTH_HEADER, "1"); // Tell the client to re-authorize by setting the reauth header
         // Construct the shop and host params from the session token (we can't get it from the query if we're making a post request)
-        const reauthUrl = `${authRoute ?? ""}${getShopAndHostQueryStringFromSessionToken(
+        const reauthUrl = `${authRoute ?? ""}?${getShopAndHostQueryStringFromSessionToken(
           sessionToken
         )}`;
         ctx.response.set(REAUTH_URL_HEADER, reauthUrl); // Set the reauth url header

--- a/src/verify-request.ts
+++ b/src/verify-request.ts
@@ -85,24 +85,16 @@ export default function verifyRequest(options?: VerifyRequestOptions) {
         const session = await exchangeSessionTokenForAccessTokenSession(
           shop,
           encodedSessionToken,
-          accessMode
+          accessMode,
+          true
         );
-        // Check if the session is valid before saving it
-        if (session.isActive()) {
-          // Save the new session
-          await Shopify.Utils.storeSession(session);
-          // Call the afterSessionRefresh callback if provided
-          const continueNext = await afterSessionRefresh?.(ctx, session);
-          if (continueNext === false) return; // If the callback returns false, then we don't continue to the next middleware
-          // Clear the top level oauth cookie since we have a valid session (maybe not necessary, but just in case)
-          setTopLevelOAuthCookieValue(ctx, null);
-          // Continue to the next middleware since the session is valid
-          return next();
-        } else {
-          console.warn(
-            `The session '${session.id}' we just got from Shopify is not active for shop '${shop}'`
-          );
-        }
+        // Call the afterSessionRefresh callback if provided
+        const continueNext = await afterSessionRefresh?.(ctx, session);
+        if (continueNext === false) return; // If the callback returns false, then we don't continue to the next middleware
+        // Clear the top level oauth cookie since we have a valid session (maybe not necessary, but just in case)
+        setTopLevelOAuthCookieValue(ctx, null);
+        // Continue to the next middleware since the session is valid
+        return next();
       }
 
       // ! Exchanging the session token for an access token failed, so we have to reauthenticate using the auth route.


### PR DESCRIPTION
In the `verifyRequest` middleware, if the online session is invalid, it will use the [token exchange API](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange) to get a new session if possible. If multiple requests come in at once, the token exchange request will be reused for all the requests for efficiency. If the token exchange fails, the old way of redirecting to get the session will be done. Installation will still be done the old way, but the token exchange will be used to prevent having to redirect to get a new online session every 24 hours. The new token exchange function has also been exported as `exchangeSessionTokenForAccessTokenSession`.

*The old way of getting the session was to redirect the app to the auth route, get the session token, and then redirect back. For API requests, it returned a header to tell the client to redirect. We still do this, but it should rarely occur anymore. This means that the `afterAuth` callback won't be called as often after getting an online session. This could be a breaking change if you rely on that callback to be called if the app is opened again after 24 hours.*

### Other important changes:
- **BREAKING:** The `validateShop`  function has been removed. Use the `Shopify.Utils.sanitizeShop` function instead.
- Invalid JWT errors (e.g. JWT expired) are now handled properly and return 401 instead of throwing a 500 server error. The header `X-Shopify-API-Request-Failure-Invalid-Session-Token` is set to `1` to alert the client of the reason for the error, so it can request a new session token and retry the request if desired.